### PR TITLE
Update example for current FluentValidation usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -142,18 +142,20 @@ public class PersonValidator : AbstractValidator<Person>
     }
 }
 
-public class ValidationTemplate : IDataErrorInfo, INotifyDataErrorInfo
+public class ValidationTemplate<T> : IDataErrorInfo, INotifyDataErrorInfo where T : INotifyPropertyChanged
 {
-    INotifyPropertyChanged target;
+    T target;
     IValidator validator;
     ValidationResult validationResult;
+    ValidationContext<T> context;
     static ConcurrentDictionary<RuntimeTypeHandle, IValidator> validators = new ConcurrentDictionary<RuntimeTypeHandle, IValidator>();
 
-    public ValidationTemplate(INotifyPropertyChanged target)
+    public ValidationTemplate(T target)
     {
         this.target = target;
         validator = GetValidator(target.GetType());
-        validationResult = validator.Validate(target);
+        context = new ValidationContext<T>(target);
+        validationResult = validator.Validate(context);
         target.PropertyChanged += Validate;
     }
 
@@ -170,7 +172,7 @@ public class ValidationTemplate : IDataErrorInfo, INotifyDataErrorInfo
 
     void Validate(object sender, PropertyChangedEventArgs e)
     {
-        validationResult = validator.Validate(target);
+        validationResult = validator.Validate(context);
         foreach (var error in validationResult.Errors)
         {
             RaiseErrorsChanged(error.PropertyName);


### PR DESCRIPTION
This PR resolves a documentation issue with the FluentValidation example, mentioned in #384. In FluentValidation 9, they removed the method the example was previously using:
https://docs.fluentvalidation.net/en/latest/upgrading-to-9.html#removal-of-non-generic-validate-overload

This is purely a documentation change. The example code for FluentValidation was made generic, and creates a ValidationContext as needed. It now does the same thing as the FluentValidation test in the project, and I verified that it compiles by dropping it into my own code that also follows the same example. 